### PR TITLE
elasticsearch: Add recovery options for locals shards after cluster restart

### DIFF
--- a/elasticsearch/elasticsearch-replicated.yml
+++ b/elasticsearch/elasticsearch-replicated.yml
@@ -31,7 +31,7 @@ objects:
     metadata:
       name: "${SERVICE_NAME}-config"
     data:
-      elasticsearch.yml: |+
+      elasticsearch.yml: |-
         cluster.name: ${SERVICE_NAME}
         node.name: ${HOSTNAME}
         network.host: 0.0.0.0
@@ -49,6 +49,24 @@ objects:
         discovery.zen.minimum_master_nodes: ${MINIMUM_MASTER_NODES}
         xpack.monitoring.history.duration: 1d
 
+        #
+        # Recovery configurations
+        #
+
+        # Enable automatic shard allocation
+        cluster.routing.allocation.enable: all
+
+        # Recover as long as this many data or master nodes
+        # have joined the cluster
+        gateway.recover_after_nodes: ${MINIMUM_MASTER_NODES}
+
+        # Recovery of local shards will start as soon as the expected
+        # number of nodes have joined the cluster
+        gateway.expected_nodes: ${ELASTIC_NODE_COUNT}
+
+        # Once the recover_after_time duration has timed out,
+        # recovery will start.
+        gateway.recover_after_time: 5m
   # A non-headless service which takes pod readiness into consideration
   - kind: Service
     apiVersion: v1


### PR DESCRIPTION
### Useful articles
* https://anchormen.nl/blog/big-data-services/elastic-search-deployment-kubernetes/
* https://stackoverflow.com/questions/19967472/elasticsearch-unassigned-shards-how-to-fix
* https://thoughts.t37.net/ce196e20ba95#de11

### Debugging failing cluster
[This article](https://medium.com/@remco_verhoef/when-everything-else-fails-cc8a27c679d0) is also helpful for users to debug a failing ES cluster.

### Manual shard re-allocation
To relocate unassigned shards manually snippet below is useful:
```sh
#!/bin/bash
array=( elasticsearch-0 elasticsearch-1 elasticsearch-2 )
node_counter=0
length=${#array[@]}
IFS=$'\n'
for line in $(curl -s 'http://127.0.0.1:9200/_cat/shards'|  fgrep UNASSIGNED); do
    INDEX=$(echo $line | (awk '{print $1}'))
    SHARD=$(echo $line | (awk '{print $2}'))
    NODE=${array[$node_counter]}
    echo $NODE
    curl -XPOST 'http://127.0.0.1:9200/_cluster/reroute' -d '{
        "commands": [
        {
            "allocate": {
                "index": "'$INDEX'",
                "shard": '$SHARD',
                "node": "'$NODE'",
                "allow_primary": true
            }
        }
        ]
    }'
    node_counter=$(((node_counter)%length +1))
done
```