### PR TITLE
memsql: Add quick start template for single-node setup

### DIFF
--- a/memsql/latest/imagestream.yml
+++ b/memsql/latest/imagestream.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Template
+objects:
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: memsql
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: memsql-latest
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: 'memsql:6.0.14'
+    runPolicy: Serial
+    source:
+      git:
+        ref: master
+        uri: 'https://github.com/abarcloud/memsql-openshift.git'
+      type: Git
+    strategy:
+      type: Docker
+    triggers:
+      - type: ConfigChange

--- a/memsql/memsql.yml
+++ b/memsql/memsql.yml
@@ -1,0 +1,141 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: memsql
+
+objects:
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: "${SERVICE_NAME}"
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: "${VOLUME_CAPACITY}"
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    generation: 1
+    labels:
+      app: ${SERVICE_NAME}
+    name: ${SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      app: ${SERVICE_NAME}
+      deploymentconfig: ${SERVICE_NAME}
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: ${SERVICE_NAME}
+          deploymentconfig: ${SERVICE_NAME}
+      spec:
+        containers:
+          - image: "172.30.150.55:5000/%NAMESPACE_HERE%/memsql:6.0.14"
+            imagePullPolicy: IfNotPresent
+            name: memsql
+            ports:
+            - containerPort: 3306
+              protocol: TCP
+            - containerPort: 9000
+              protocol: TCP
+            readinessProbe:
+              tcpSocket:
+                port: 9000
+              initialDelaySeconds: 30
+              timeoutSeconds: 1
+            livenessProbe:
+              tcpSocket:
+                port: 9000
+              initialDelaySeconds: 300
+              timeoutSeconds: 10
+            env:
+            - name: MEMORY_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '0'
+                  resource: limits.memory
+            resources:
+              limits:
+                memory: ${MEMORY_LIMIT}
+            terminationMessagePath: /dev/termination-log
+            volumeMounts:
+            - name: ${SERVICE_NAME}-data
+              mountPath: /data
+        volumes:
+        - name: "${SERVICE_NAME}-data"
+          persistentVolumeClaim:
+            claimName: "${SERVICE_NAME}"
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 30
+    triggers:
+    - type: ConfigChange
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+    labels:
+      app: "${SERVICE_NAME}"
+    name: "${SERVICE_NAME}-db"
+  spec:
+    ports:
+    - name: 3306-tcp
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      app: "${SERVICE_NAME}"
+      deploymentconfig: "${SERVICE_NAME}"
+    sessionAffinity: None
+    type: ClusterIP
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+    labels:
+      app: "${SERVICE_NAME}"
+    name: "${SERVICE_NAME}-web"
+  spec:
+    ports:
+    - name: 9000-tcp
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    selector:
+      app: "${SERVICE_NAME}"
+      deploymentconfig: "${SERVICE_NAME}"
+    sessionAffinity: None
+    type: ClusterIP
+
+parameters:
+- name: SERVICE_NAME
+  displayName: Service Name
+  description: The name used when creating the required deployment config,
+    service etc. Must be unique and contain only lower-case letters.
+  value: memsql
+  required: true
+- displayName: Memory Limit
+  description: Maximum amount of memory the container can use, e.g. 1000Mi, 3000Mi. This
+    can be modified later in the DeploymentConfig.
+  name: MEMORY_LIMIT
+  required: true
+  value: 2000Mi
+- name: VOLUME_CAPACITY
+  displayName: Volume Capacity
+  description: Volume space available for data, e.g. 1Gi, 5Gi.
+  value: 1Gi
+  required: true


### PR DESCRIPTION
This template is just a quick start and needs a lot more fine tuning for a production use.

Below is minimum memory needed when trying to create new databases:
* **1000Mi** is enough for:
   * `CREATE DATABASE db_name WITH SYNC REPLICATION PARTITIONS 3`
   * Cannot run any `ASYNC` statements.
* **2000Mi** is enough for:
   * `CREATE DATABASE db_name WITH SYNC REPLICATION PARTITIONS 4`
   * `CREATE DATABASE db_name WITH ASYNC REPLICATION PARTITIONS 3`


## Release Steps
- [ ] Create `abarcloud/memsql-openshift` repository off of [aramalipoor/memsql-openshift](https://github.com/aramalipoor/memsql-openshift)
- [ ] In abar-tempates repo run `make memsql/`
